### PR TITLE
More visible scrollbar

### DIFF
--- a/themes/Loved-color-theme.json
+++ b/themes/Loved-color-theme.json
@@ -17,9 +17,9 @@
 		"input.border": "#0000",
 		
 		"scrollbar.shadow": "#0000",
-		"scrollbarSlider.background": "#99beff08",
-		"scrollbarSlider.activeBackground": "#99beff10",
-		"scrollbarSlider.hoverBackground": "#99beff16",
+		"scrollbarSlider.background": "#75809555",
+		"scrollbarSlider.activeBackground": "#75809590",
+		"scrollbarSlider.hoverBackground": "#75809590",
 
 		"badge.background": "#0c111a",
 


### PR DESCRIPTION
First, thank you for making this VSCode theme.
I really loved the original Atom theme by @DanielPintilei . I recently switched from Atom to VSCode and glad I found this adaptation.

Though, I found a minor issue that scrollbar isn't much visible for me. I think the transparency is a bit too high.

So I changed `scrollbarSlider.background` to be the same color as `editorLineNumber.foreground` `#75809590` but a bit more transparent.

Also I made `scrollbarSlider.activeBackground` and `scrollbarSlider.hoverBackground` are little less transparent.

Before:
<img width="57" alt="Screen Shot 2022-12-19 at 17 01 56" src="https://user-images.githubusercontent.com/3948302/208376555-8804b17c-1c75-4b04-beec-c001223a79da.png">

After:
<img width="48" alt="Screen Shot 2022-12-19 at 17 03 02" src="https://user-images.githubusercontent.com/3948302/208376600-74770cc4-fb5b-46e2-ae87-a8c899858a16.png">
